### PR TITLE
Upgraded to Lagom 1.3.3 (#38)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@
 //
 
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.2")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.3")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
 // The ConductR plugin

--- a/search-impl/src/main/scala/com/example/auction/search/SearchApplicationLoader.scala
+++ b/search-impl/src/main/scala/com/example/auction/search/SearchApplicationLoader.scala
@@ -28,10 +28,7 @@ abstract class SearchApplication(context: LagomApplicationContext) extends Lagom
 
   lazy val indexedStore:IndexedStore[SearchResult] = wire[ElasticSearchIndexedStore]
 
-  override lazy val lagomServer = LagomServer.forServices(
-    bindService[SearchService].to(wire[SearchServiceImpl]),
-    metricsServiceBinding
-  )
+  override lazy val lagomServer = serverFor[SearchService](wire[SearchServiceImpl])
 
   wire[BrokerEventConsumer]
 

--- a/user-impl/src/main/scala/com/example/auction/user/impl/UserApplicationLoader.scala
+++ b/user-impl/src/main/scala/com/example/auction/user/impl/UserApplicationLoader.scala
@@ -4,6 +4,7 @@ import com.example.auction.user.api.UserService
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraPersistenceComponents
 import com.lightbend.lagom.scaladsl.server._
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
 import com.softwaremill.macwire._
 import com.typesafe.conductr.bundlelib.lagom.scaladsl.ConductRApplicationComponents
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -13,9 +14,7 @@ abstract class UserApplication(context: LagomApplicationContext)
     with AhcWSComponents
     with CassandraPersistenceComponents {
 
-  override lazy val lagomServer = LagomServer.forServices(
-    bindService[UserService].to(wire[UserServiceImpl])
-  )
+  override lazy val lagomServer = serverFor[UserService](wire[UserServiceImpl])
   override lazy val jsonSerializerRegistry = UserSerializerRegistry
 
   persistentEntityRegistry.register(wire[UserEntity])
@@ -23,7 +22,10 @@ abstract class UserApplication(context: LagomApplicationContext)
 
 class UserApplicationLoader extends LagomApplicationLoader {
   override def load(context: LagomApplicationContext) =
-    new UserApplication(context) with ConductRApplicationComponents
+    new UserApplication(context) with ConductRApplicationComponents {
+
+    override lazy val circuitBreakerMetricsProvider = new CircuitBreakerMetricsProviderImpl(actorSystem)
+  }
 
   override def loadDevMode(context: LagomApplicationContext) =
     new UserApplication(context) with LagomDevModeComponents

--- a/web-gateway/app/Loader.scala
+++ b/web-gateway/app/Loader.scala
@@ -4,6 +4,7 @@ import com.example.auction.user.api.UserService
 import com.lightbend.lagom.scaladsl.api.{ ServiceAcl, ServiceInfo }
 import com.lightbend.lagom.scaladsl.client.LagomServiceClientComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
 import com.softwaremill.macwire._
 import com.typesafe.conductr.bundlelib.lagom.scaladsl.ConductRApplicationComponents
 import controllers.{ Assets, ItemController, Main, ProfileController }
@@ -48,6 +49,8 @@ class WebGatewayLoader extends ApplicationLoader {
     case Mode.Dev =>
       (new WebGateway(context) with LagomDevModeComponents).application
     case _ =>
-      (new WebGateway(context) with ConductRApplicationComponents).application
+      (new WebGateway(context) with ConductRApplicationComponents {
+        override lazy val circuitBreakerMetricsProvider = new CircuitBreakerMetricsProviderImpl(actorSystem)
+      }).application
   }
 }


### PR DESCRIPTION
The circuit breaker metrics provider change means that now both ConductR
and Lagom provides circuitBreakerMetricsProvider. ConductR will need to
be modified to not provide it, in the meantime, overriding it like this
is the work around.