### PR TITLE
Updated URL for lightbend helm charts (#104)

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -77,7 +77,7 @@ The `reactive-sandbox` allows you to easily test your deployment with Cassandra,
 
 ```bash
 helm init
-helm repo add lightbend-helm-charts https://lightbend.github.io/helm-charts
+helm repo add lightbend-helm-charts https://repo.lightbend.com/helm-charts
 helm repo update
 ```
 


### PR DESCRIPTION
The URL for lightbend-helm-charts has changed. 

Fixes: https://github.com/lagom/online-auction-scala/issues/103